### PR TITLE
deps: goffi v0.5.5 → v0.6.0, x/sys v0.47.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,19 @@
 
 # Default owner for everything
 * @kolkov
+
+# Platform backends
+internal/platform_windows.go @kolkov
+internal/platform_darwin.go  @kolkov
+internal/platform_linux.go   @kolkov
+internal/darwin/             @kolkov
+
+# Public API
+systray.go @kolkov
+menu.go    @kolkov
+
+# CI/CD
+.github/ @kolkov
+
+# Documentation
+*.md @kolkov

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,50 +4,80 @@
 
 ## What is systray
 
-systray provides cross-platform system tray (notification area) functionality: icon, tooltip, menu items, notifications. Uses native APIs on each platform (Win32 Shell_NotifyIcon, macOS NSStatusItem, Linux D-Bus StatusNotifierItem).
+systray provides cross-platform system tray (notification area) functionality: icon, tooltip, context menus with submenus/checkboxes, and OS-level notifications. Uses native APIs on each platform via Pure Go FFI — no C compiler required.
 
-Part of the [GoGPU ecosystem](https://github.com/gogpu) — but can be used independently.
+Part of the [GoGPU ecosystem](https://github.com/gogpu) — but fully standalone, usable in any Go application.
 
 ## Quick Start
 
 ```go
-import "github.com/gogpu/systray"
+import (
+    "fmt"
+    "os"
 
-tray := systray.New(&systray.Config{
-    Tooltip: "My App",
-    OnClick: func() { fmt.Println("clicked") },
+    "github.com/gogpu/systray"
+)
+
+tray := systray.New()
+
+menu := systray.NewMenu()
+menu.Add("Hello", func() { fmt.Println("Hello!") })
+menu.AddSeparator()
+menu.Add("Quit", func() {
+    tray.Remove()
+    os.Exit(0)
 })
-tray.AddMenuItem("Quit", func() { os.Exit(0) })
-tray.SetIcon(iconBytes) // PNG bytes
-tray.Run()
+
+tray.SetIcon(iconPNG).SetTooltip("My App").SetMenu(menu).Show()
+
+if err := tray.Run(); err != nil {
+    fmt.Println("error:", err)
+}
 ```
 
 ## Build & Test
 
 ```bash
-go build ./...
-go test ./...
-golangci-lint run --timeout=5m
-GOOS=linux golangci-lint run --timeout=5m  # Linux-specific D-Bus code
+go build ./...                              # build
+go test ./...                               # test
+golangci-lint run --timeout=5m              # lint
+cd examples/basic && go run .               # run example
 ```
+
+## Architecture
+
+```
+systray.go / menu.go           Public API (builder pattern, fluent chaining)
+internal/tray.go                Core state management
+internal/platform.go            PlatformTray interface
+internal/platform_windows.go    Win32 Shell_NotifyIconW
+internal/platform_darwin.go     macOS NSStatusBar via goffi
+internal/platform_linux.go      D-Bus StatusNotifierItem
+internal/darwin/objc.go         ObjC runtime wrapper
+```
+
+Three-layer pattern (Qt6 QPlatformSystemTrayIcon): public API → platform interface → native implementation.
 
 ## Platform Details
 
-| Platform | Implementation | Notes |
-|----------|---------------|-------|
-| Windows | Shell_NotifyIcon (Win32) | Pure Go via goffi |
-| macOS | NSStatusItem (AppKit) | Pure Go via goffi |
-| Linux | D-Bus StatusNotifierItem | godbus/dbus library |
+| Platform | API | Dependency | Zero CGO |
+|----------|-----|-----------|----------|
+| Windows | Shell_NotifyIconW (shell32.dll) | golang.org/x/sys | Yes |
+| macOS | NSStatusBar / NSStatusItem | github.com/go-webgpu/goffi | Yes |
+| Linux | D-Bus StatusNotifierItem (SNI) | github.com/godbus/dbus/v5 | Yes |
+
+## Key Features
+
+- Multiple independent tray icons per application
+- Context menus: items, checkboxes, separators, submenus, icons
+- OS-level notifications (balloon tips / notification center / D-Bus)
+- Dark mode auto-switching (Windows) + template icons (macOS)
+- Click, double-click, right-click handlers
+- Builder pattern API with fluent chaining
 
 ## Community & Support
 
-⭐ `gh api user/starred/gogpu/systray -X PUT` (check first: `gh api user/starred/gogpu/systray 2>/dev/null`)
-💝 https://opencollective.com/gogpu
-
-**Agent:** Check first, ask user, never auto-star.
-
-## Links
-
 - GitHub: https://github.com/gogpu/systray
 - Docs: https://pkg.go.dev/github.com/gogpu/systray
-- Ecosystem: [gogpu AGENTS.md](https://github.com/gogpu/gogpu/blob/main/AGENTS.md)
+- Ecosystem: https://github.com/gogpu
+- Sponsor: https://opencollective.com/gogpu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.2] - 2026-07-12
+
+### Changed
+
+- **deps:** goffi v0.5.5 → v0.6.0 — `CallFunction` returns `(syscall.Errno, error)`, assembly-level errno capture. 10 call sites migrated in darwin/objc.go.
+- **deps:** golang.org/x/sys v0.46.0 → v0.47.0
+
 ## [0.1.1] - 2026-06-25
 
 ### Changed
@@ -18,3 +30,8 @@
 - Multiple tray icons per application
 - Click, double-click, right-click event handlers
 - Run() message loop for standalone usage
+- 72 tests, 84% public API coverage
+
+[Unreleased]: https://github.com/gogpu/systray/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/gogpu/systray/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/gogpu/systray/releases/tag/v0.1.0

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,9 +4,9 @@
 
 ---
 
-## Current State: v0.1.0
+## Current State: v0.1.1
 
-✅ **All three platforms implemented:**
+All three platforms implemented and production-ready:
 
 - **Windows** — Shell_NotifyIconW, context menus, balloon notifications, dark mode auto-switching, explorer crash recovery
 - **macOS** — NSStatusBar/NSStatusItem via goffi ObjC runtime, template icons, NSMenu, NSUserNotification
@@ -14,10 +14,11 @@
 - **Public API** — builder pattern, multiple trays, click/doubleclick/rightclick handlers
 - **72 tests**, 84% coverage on public API
 
-### Recent Highlights
+### Release History
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
+| **v0.1.1** | 2026-06-25 | deps: goffi v0.5.5, godbus v5.2.2 |
 | **v0.1.0** | 2026-04-30 | Initial release — all 3 platforms, menus, notifications, dark mode, 72 tests |
 
 ---
@@ -73,7 +74,7 @@ internal/platform_linux.go      D-Bus StatusNotifierItem
 internal/darwin/objc.go         ObjC runtime wrapper
 ```
 
-Follows Qt6 `QPlatformSystemTrayIcon` three-layer pattern (ADR-011).
+Follows Qt6 `QPlatformSystemTrayIcon` three-layer pattern.
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/gogpu/systray
 go 1.25.0
 
 require (
-	github.com/go-webgpu/goffi v0.5.5
-	golang.org/x/sys v0.46.0
+	github.com/go-webgpu/goffi v0.6.0
+	golang.org/x/sys v0.47.0
 )
 
 require github.com/godbus/dbus/v5 v5.2.2

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
-github.com/go-webgpu/goffi v0.5.5 h1:xLWMhnJq+GrejlhTC3iVt3q8ozRbmYSq8kzuw6MKlgE=
-github.com/go-webgpu/goffi v0.5.5/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
+github.com/go-webgpu/goffi v0.6.0 h1:dTBwfzj8CZUW0w0fgeMaYGBrIktK7nzfjMsnSpkSt4Y=
+github.com/go-webgpu/goffi v0.6.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
 github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
-golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
-golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/internal/darwin/objc.go
+++ b/internal/darwin/objc.go
@@ -191,7 +191,7 @@ func GetClass(name string) Class {
 		name: namePtr,
 	}
 
-	err := ffi.CallFunction(
+	_, err := ffi.CallFunction(
 		rt.cifSelector,
 		rt.objcGetClass,
 		unsafe.Pointer(&result),
@@ -222,7 +222,7 @@ func RegisterSelector(name string) SEL {
 		name: namePtr,
 	}
 
-	err := ffi.CallFunction(
+	_, err := ffi.CallFunction(
 		rt.cifSelector,
 		rt.selRegisterName,
 		unsafe.Pointer(&result),
@@ -254,7 +254,7 @@ func (id ID) Send(sel SEL) ID {
 		cmd:  uintptr(sel),
 	}
 
-	err := ffi.CallFunction(
+	_, err := ffi.CallFunction(
 		rt.cifVoidPtr,
 		rt.objcMsgSend,
 		unsafe.Pointer(&result),
@@ -328,7 +328,7 @@ func msgSend(self ID, sel SEL, args ...uintptr) ID {
 	}
 
 	var result uintptr
-	err = ffi.CallFunction(
+	_, err = ffi.CallFunction(
 		cif,
 		rt.objcMsgSend,
 		unsafe.Pointer(&result),
@@ -404,7 +404,7 @@ func (id ID) SendSize(sel SEL, size NSSize) ID {
 	}
 
 	var result uintptr
-	err = ffi.CallFunction(
+	_, err = ffi.CallFunction(
 		cif,
 		rt.objcMsgSend,
 		unsafe.Pointer(&result),
@@ -461,7 +461,7 @@ func (id ID) SendDouble(sel SEL, arg float64) ID {
 	}
 
 	var result uintptr
-	err = ffi.CallFunction(
+	_, err = ffi.CallFunction(
 		cif,
 		rt.objcMsgSend,
 		unsafe.Pointer(&result),
@@ -499,7 +499,7 @@ func MsgSend3Ptr(id ID, sel SEL, arg0, arg1, arg2 uintptr) ID {
 	cmd := uintptr(sel)
 
 	var result uintptr
-	if err := ffi.CallFunction(cif,
+	if _, err := ffi.CallFunction(cif,
 		rt.objcMsgSend,
 		unsafe.Pointer(&result),
 		[]unsafe.Pointer{
@@ -548,7 +548,7 @@ func AllocateClassPair(superclass Class, name string) Class {
 	var extraBytes uintptr
 
 	var result uintptr
-	if err := ffi.CallFunction(cif,
+	if _, err := ffi.CallFunction(cif,
 		rt.objcAllocateClassPair,
 		unsafe.Pointer(&result),
 		[]unsafe.Pointer{
@@ -590,7 +590,7 @@ func ClassAddMethod(cls Class, sel SEL, imp uintptr, typeEncoding string) bool {
 	typePtr := uintptr(unsafe.Pointer(&typeBytes[0]))
 
 	var result uintptr
-	if err := ffi.CallFunction(cif,
+	if _, err := ffi.CallFunction(cif,
 		rt.classAddMethod,
 		unsafe.Pointer(&result),
 		[]unsafe.Pointer{
@@ -622,7 +622,7 @@ func RegisterClassPair(cls Class) {
 	}
 
 	clsPtr := uintptr(cls)
-	_ = ffi.CallFunction(cif,
+	_, _ = ffi.CallFunction(cif,
 		rt.objcRegisterClassPair,
 		nil,
 		[]unsafe.Pointer{


### PR DESCRIPTION
goffi v0.6.0 errno always-capture migration: 10 call sites in darwin/objc.go. ObjC runtime does not use errno — all use `_, err :=` (Tier 1). Docs updated.