### PR TITLE
release: v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2026-08-05
+
+### Fixed
+
+- **Windows: submenu clicks dispatched to wrong callback.** `TrackPopupMenu` returned per-HMENU positional IDs (1,2,3 per submenu level), causing submenu items to invoke root-menu callbacks. Replaced with globally unique command IDs + flat `cmdItems` dispatch map across all menu levels. ([#12](https://github.com/gogpu/systray/issues/12))
+- **Windows: `SetLabel`/`SetChecked`/`SetDisabled` had no effect on submenu items.** `SetMenuItemInfoW` searched only the root HMENU. Now stores per-item HMENU handle in `itemHMenus` map for correct submenu targeting. ([#13](https://github.com/gogpu/systray/issues/13))
+- **Windows: `tray.Remove()` left process running.** `Run()` never returned because `DestroyWindow` posts `WM_DESTROY` but `GetMessage` only exits on `WM_QUIT`. Added `PostQuitMessage(0)` in `WM_DESTROY` handler. ([#14](https://github.com/gogpu/systray/issues/14))
+
+### Added
+
+- `MenuItem.IsChecked()` and `MenuItem.IsDisabled()` — thread-safe getters for current state. ([#15](https://github.com/gogpu/systray/issues/15))
+
+### Changed
+
+- **deps:** goffi v0.6.2 → v0.6.3
+
 ## [0.2.1] - 2026-07-28
 
 ### Fixed
@@ -59,7 +75,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Run() message loop for standalone usage
 - 72 tests, 84% public API coverage
 
-[Unreleased]: https://github.com/gogpu/systray/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/gogpu/systray/compare/v0.2.2...HEAD
+[0.2.2]: https://github.com/gogpu/systray/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/gogpu/systray/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/gogpu/systray/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/gogpu/systray/compare/v0.1.1...v0.1.2

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,6 +18,7 @@ All three platforms implemented and production-ready:
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
+| **v0.2.2** | 2026-08-05 | Fix Windows submenu dispatch, UpdateItem on submenus, Run() exit; IsChecked/IsDisabled getters |
 | **v0.2.1** | 2026-07-28 | Fix macOS crash on background goroutine menu updates (main thread dispatch) |
 | **v0.2.0** | 2026-07-27 | Multi-tray fix (macOS/Linux), dynamic menu updates, breaking API (Add returns *MenuItem) |
 | **v0.1.2** | 2026-07-12 | deps: goffi v0.6.0, x/sys v0.47.0 |

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/systray
 go 1.25.0
 
 require (
-	github.com/go-webgpu/goffi v0.6.2
+	github.com/go-webgpu/goffi v0.6.3
 	golang.org/x/sys v0.47.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/go-webgpu/goffi v0.6.0 h1:dTBwfzj8CZUW0w0fgeMaYGBrIktK7nzfjMsnSpkSt4Y
 github.com/go-webgpu/goffi v0.6.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/goffi v0.6.2 h1:xuMaUbqsNQ/xiyy5UwAKZb5vQZUDg9QRCrJIpHJaXSE=
 github.com/go-webgpu/goffi v0.6.2/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
+github.com/go-webgpu/goffi v0.6.3 h1:p4gKGikHBAQ/8iUiew9MV4C5M1ZGIsk8QGFGuJjMj+A=
+github.com/go-webgpu/goffi v0.6.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
 github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=

--- a/internal/menu.go
+++ b/internal/menu.go
@@ -39,6 +39,22 @@ type MenuItem struct {
 // ID returns the unique identifier for this menu item.
 func (item *MenuItem) ID() uint32 { return item.id }
 
+// IsChecked returns the current checked state. Thread-safe.
+func (item *MenuItem) IsChecked() bool {
+	item.mu.Lock()
+	v := item.Checked
+	item.mu.Unlock()
+	return v
+}
+
+// IsDisabled returns the current disabled state. Thread-safe.
+func (item *MenuItem) IsDisabled() bool {
+	item.mu.Lock()
+	v := item.Disabled
+	item.mu.Unlock()
+	return v
+}
+
 // SetLabel changes the display text and dispatches the update to the native platform.
 func (item *MenuItem) SetLabel(label string) {
 	item.mu.Lock()

--- a/internal/platform_windows.go
+++ b/internal/platform_windows.go
@@ -142,6 +142,7 @@ var (
 	procDispatchMessageW            = user32.NewProc("DispatchMessageW")
 	procShellNotifyIconGetRect      = shell32.NewProc("Shell_NotifyIconGetRect")
 	procSetMenuItemInfoW            = user32.NewProc("SetMenuItemInfoW")
+	procPostQuitMessage             = user32.NewProc("PostQuitMessage")
 )
 
 // menuItemInfoW is the Win32 MENUITEMINFOW structure for SetMenuItemInfoW.
@@ -254,16 +255,21 @@ type win32Tray struct {
 	iconDark []byte  // dark mode icon PNG for automatic theme switching
 	tooltip  string  // stored tooltip for explorer crash recovery
 
-	callbacks *Callbacks
-	menu      *Menu             // stored menu for rebuilding HMENU and dispatch
-	itemIDs   map[uint32]uint32 // MenuItem.ID() -> HMENU command ID (UINT) for UpdateItem
+	callbacks  *Callbacks
+	menu       *Menu                // stored menu for rebuilding HMENU and dispatch
+	itemIDs    map[uint32]uint32    // MenuItem.ID() -> HMENU command ID (UINT) for UpdateItem
+	itemHMenus map[uint32]uintptr   // MenuItem.ID() -> owning HMENU handle (for submenu UpdateItem)
+	cmdItems   map[uint32]*MenuItem // command ID -> MenuItem for click dispatch (flat, includes submenus)
+	nextCmdID  uint32               // global command ID counter (1-based, increments across submenus)
 }
 
 // NewPlatformTray creates a Win32 system tray implementation.
 func NewPlatformTray(callbacks *Callbacks) PlatformTray {
 	return &win32Tray{
-		callbacks: callbacks,
-		itemIDs:   make(map[uint32]uint32),
+		callbacks:  callbacks,
+		itemIDs:    make(map[uint32]uint32),
+		itemHMenus: make(map[uint32]uintptr),
+		cmdItems:   make(map[uint32]*MenuItem),
 	}
 }
 
@@ -442,6 +448,9 @@ func (t *win32Tray) SetTooltip(text string) error {
 func (t *win32Tray) SetMenu(menu *Menu) error {
 	t.menu = menu
 	t.itemIDs = make(map[uint32]uint32)
+	t.itemHMenus = make(map[uint32]uintptr)
+	t.cmdItems = make(map[uint32]*MenuItem)
+	t.nextCmdID = 1
 
 	// Destroy old HMENU if any.
 	if t.hmenu != 0 {
@@ -452,7 +461,7 @@ func (t *win32Tray) SetMenu(menu *Menu) error {
 	}
 
 	if menu != nil && len(menu.Items) > 0 {
-		hmenu, err := buildHMENU(menu, t.itemIDs)
+		hmenu, err := t.buildHMENU(menu)
 		if err != nil {
 			return fmt.Errorf("build HMENU: %w", err)
 		}
@@ -724,16 +733,14 @@ func (t *win32Tray) reAddIcon() {
 // --- Menu construction ---
 
 // buildHMENU creates a Win32 HMENU from the internal Menu structure.
-// Menu item IDs are 1-based sequential (0 is reserved for "no selection"
-// in TrackPopupMenu with TPM_RETURNCMD).
-// itemIDs maps MenuItem.ID() to the Win32 command ID for UpdateItem.
-func buildHMENU(menu *Menu, itemIDs map[uint32]uint32) (uintptr, error) {
+// Command IDs are globally unique across all submenus (allocated from t.nextCmdID).
+func (t *win32Tray) buildHMENU(menu *Menu) (uintptr, error) {
 	hmenu, _, _ := procCreatePopupMenu.Call()
 	if hmenu == 0 {
 		return 0, fmt.Errorf("CreatePopupMenu failed")
 	}
 
-	if err := populateMenu(hmenu, menu, itemIDs); err != nil {
+	if err := t.populateMenu(hmenu, menu); err != nil {
 		if ret, _, _ := procDestroyMenu.Call(hmenu); ret == 0 {
 			slog.Warn("systray: DestroyMenu failed during error cleanup")
 		}
@@ -744,10 +751,9 @@ func buildHMENU(menu *Menu, itemIDs map[uint32]uint32) (uintptr, error) {
 }
 
 // populateMenu recursively adds items to an HMENU.
-// Item IDs are assigned sequentially using a global counter that resets
-// when buildHMENU is called. For submenus, items continue the sequence.
-// itemIDs maps MenuItem.ID() to the Win32 command ID.
-func populateMenu(hmenu uintptr, menu *Menu, itemIDs map[uint32]uint32) error {
+// Each non-separator, non-submenu item gets a globally unique command ID
+// from t.nextCmdID, ensuring submenus dispatch correctly.
+func (t *win32Tray) populateMenu(hmenu uintptr, menu *Menu) error {
 	for i, item := range menu.Items {
 		switch item.Type {
 		case MenuItemSeparator:
@@ -765,13 +771,12 @@ func populateMenu(hmenu uintptr, menu *Menu, itemIDs map[uint32]uint32) error {
 			if item.Submenu == nil {
 				continue
 			}
-			subHMenu, err := buildHMENU(item.Submenu, itemIDs)
+			subHMenu, err := t.buildHMENU(item.Submenu)
 			if err != nil {
 				return fmt.Errorf("build submenu %q: %w", item.Label, err)
 			}
 			label, err := windows.UTF16PtrFromString(item.Label)
 			if err != nil {
-				// Best-effort cleanup of already-created submenu handle.
 				_, _, _ = procDestroyMenu.Call(subHMenu)
 				return fmt.Errorf("utf16 submenu label %q: %w", item.Label, err)
 			}
@@ -786,7 +791,6 @@ func populateMenu(hmenu uintptr, menu *Menu, itemIDs map[uint32]uint32) error {
 				uintptr(unsafe.Pointer(label)),
 			)
 			if ret == 0 {
-				// Best-effort cleanup of already-created submenu handle.
 				_, _, _ = procDestroyMenu.Call(subHMenu)
 				return fmt.Errorf("AppendMenuW submenu %q failed", item.Label)
 			}
@@ -803,33 +807,34 @@ func populateMenu(hmenu uintptr, menu *Menu, itemIDs map[uint32]uint32) error {
 			if item.Disabled {
 				flags |= mfGrayed
 			}
-			// Item ID is 1-based index (UINT). Cast to uintptr only at syscall boundary.
-			itemID := uint32(i + 1)
+			cmdID := t.nextCmdID
+			t.nextCmdID++
 			ret, _, _ := procAppendMenuW.Call(
 				hmenu,
 				flags,
-				uintptr(itemID),
+				uintptr(cmdID),
 				uintptr(unsafe.Pointer(label)),
 			)
 			if ret == 0 {
 				return fmt.Errorf("AppendMenuW item %q failed", item.Label)
 			}
-			if itemIDs != nil {
-				itemIDs[item.ID()] = itemID
-			}
+			t.itemIDs[item.ID()] = cmdID
+			t.itemHMenus[item.ID()] = hmenu
+			t.cmdItems[cmdID] = item
 		}
 	}
 	return nil
 }
 
 // UpdateItem updates a single menu item's native properties in-place via SetMenuItemInfoW.
+// Uses the per-item HMENU handle to correctly update items in submenus.
 func (t *win32Tray) UpdateItem(item *MenuItem) error {
-	if t.hmenu == 0 {
-		return nil
-	}
-
 	cmdID, ok := t.itemIDs[item.ID()]
 	if !ok {
+		return nil
+	}
+	hmenu, ok := t.itemHMenus[item.ID()]
+	if !ok || hmenu == 0 {
 		return nil
 	}
 
@@ -853,7 +858,7 @@ func (t *win32Tray) UpdateItem(item *MenuItem) error {
 		dwTypeData: uintptr(unsafe.Pointer(label)),
 	}
 
-	ret, _, _ := procSetMenuItemInfoW.Call(t.hmenu, uintptr(cmdID), 0, uintptr(unsafe.Pointer(&mii)))
+	ret, _, _ := procSetMenuItemInfoW.Call(hmenu, uintptr(cmdID), 0, uintptr(unsafe.Pointer(&mii)))
 	if ret == 0 {
 		return fmt.Errorf("SetMenuItemInfoW failed for item %q", item.Label)
 	}
@@ -901,6 +906,7 @@ func trayWndProc(hwnd uintptr, msg uint32, wParam, lParam uintptr) uintptr {
 		return ret
 
 	case wmDestroy:
+		procPostQuitMessage.Call(0)
 		return 0
 
 	default:
@@ -974,14 +980,10 @@ func (t *win32Tray) showContextMenu() {
 	// Return value is non-fatal.
 	_, _, _ = procPostMessageW.Call(t.hwnd, wmNull, 0, 0)
 
-	// Dispatch the selected item (ret is 1-based index from populateMenu).
-	if ret > 0 && t.menu != nil {
-		idx := int(ret) - 1
-		if idx >= 0 && idx < len(t.menu.Items) {
-			item := t.menu.Items[idx]
-			if item.OnClick != nil {
-				item.OnClick()
-			}
+	// Dispatch via globally unique command ID → MenuItem map.
+	if ret > 0 {
+		if item, ok := t.cmdItems[uint32(ret)]; ok && item.OnClick != nil {
+			item.OnClick()
 		}
 	}
 }

--- a/menu.go
+++ b/menu.go
@@ -20,6 +20,16 @@ type MenuItem struct {
 	impl *internal.MenuItem
 }
 
+// IsChecked returns the current checked state. Thread-safe.
+func (item *MenuItem) IsChecked() bool {
+	return item.impl.IsChecked()
+}
+
+// IsDisabled returns the current disabled state. Thread-safe.
+func (item *MenuItem) IsDisabled() bool {
+	return item.impl.IsDisabled()
+}
+
 // SetLabel changes the display text and updates the native menu item.
 func (item *MenuItem) SetLabel(label string) {
 	item.impl.SetLabel(label)


### PR DESCRIPTION
## v0.2.2

### Fixed

- **Windows: submenu clicks dispatched to wrong callback.** Replaced per-HMENU positional IDs with globally unique command IDs + flat dispatch map across all menu levels (#12)
- **Windows: SetLabel/SetChecked/SetDisabled had no effect on submenu items.** Store per-item HMENU handle for correct submenu targeting in SetMenuItemInfoW (#13)
- **Windows: tray.Remove() left process running.** Added PostQuitMessage(0) in WM_DESTROY handler so Run() returns (#14)

### Added

- `MenuItem.IsChecked()` and `MenuItem.IsDisabled()` — thread-safe getters (#15)

### Changed

- deps: goffi v0.6.2 → v0.6.3