### PR TITLE
release: v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2026-08-05
+
+### Fixed
+
+- **Windows: `tray.Remove()` from background goroutine failed.** `DestroyWindow` must be called from the thread that owns the HWND. Replaced with `PostMessage(WM_CLOSE)` which is thread-safe — `DefWindowProc` handles `WM_CLOSE` → `DestroyWindow` → `WM_DESTROY` → `PostQuitMessage` on the correct thread. ([#14](https://github.com/gogpu/systray/issues/14))
+- **macOS: `tray.Remove()` from background goroutine crashed (SIGTRAP).** All AppKit calls (`removeStatusItem`, `release`, `stop`) must execute on the main thread. `Destroy()` now dispatches via `performSelectorOnMainThread` using a nil sentinel in the pending updates channel. ([#14](https://github.com/gogpu/systray/issues/14))
+
 ## [0.2.2] - 2026-08-05
 
 ### Fixed
@@ -75,7 +82,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Run() message loop for standalone usage
 - 72 tests, 84% public API coverage
 
-[Unreleased]: https://github.com/gogpu/systray/compare/v0.2.2...HEAD
+[Unreleased]: https://github.com/gogpu/systray/compare/v0.2.3...HEAD
+[0.2.3]: https://github.com/gogpu/systray/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/gogpu/systray/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/gogpu/systray/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/gogpu/systray/compare/v0.1.2...v0.2.0

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,6 +18,7 @@ All three platforms implemented and production-ready:
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
+| **v0.2.3** | 2026-08-05 | Fix Destroy() from background goroutine (Windows PostMessage, macOS main thread dispatch) |
 | **v0.2.2** | 2026-08-05 | Fix Windows submenu dispatch, UpdateItem on submenus, Run() exit; IsChecked/IsDisabled getters |
 | **v0.2.1** | 2026-07-28 | Fix macOS crash on background goroutine menu updates (main thread dispatch) |
 | **v0.2.0** | 2026-07-27 | Multi-tray fix (macOS/Linux), dynamic menu updates, breaking API (Add returns *MenuItem) |

--- a/internal/platform_darwin.go
+++ b/internal/platform_darwin.go
@@ -614,10 +614,15 @@ func (t *darwinTray) UpdateItem(item *MenuItem) error {
 
 // applyPendingUpdates drains the pendingUpdates channel and applies AppKit
 // changes. MUST be called on the main thread (via drainUpdates: ObjC callback).
+// A nil item signals Destroy.
 func (t *darwinTray) applyPendingUpdates() {
 	for {
 		select {
 		case item := <-t.pendingUpdates:
+			if item == nil {
+				t.destroyOnMainThread()
+				return
+			}
 			t.applyItemUpdate(item)
 		default:
 			return
@@ -794,7 +799,24 @@ func (t *darwinTray) Run() error {
 }
 
 // Destroy releases all resources associated with the tray icon.
+// Safe to call from any goroutine — AppKit calls are dispatched to the main
+// thread via performSelectorOnMainThread.
 func (t *darwinTray) Destroy() {
+	if t.target.IsNil() {
+		return
+	}
+
+	// Queue the cleanup work for main thread execution.
+	t.pendingUpdates <- nil // nil sentinel signals destroy
+
+	drainSel := darwin.RegisterSelector("drainUpdates:")
+	darwin.MsgSend3Ptr(t.target, darwinSels.performSelectorOnMainThread,
+		uintptr(drainSel), 0, 1) // waitUntilDone:YES
+}
+
+// destroyOnMainThread performs the actual AppKit cleanup.
+// MUST be called on the main thread.
+func (t *darwinTray) destroyOnMainThread() {
 	// Remove the status item from the menu bar.
 	if !t.statusBar.IsNil() && !t.statusItem.IsNil() {
 		t.statusBar.SendPtr(darwinSels.removeStatusItem, t.statusItem.Ptr())

--- a/internal/platform_windows.go
+++ b/internal/platform_windows.go
@@ -119,10 +119,10 @@ var (
 	shell32  = windows.NewLazySystemDLL("shell32.dll")
 	kernel32 = windows.NewLazySystemDLL("kernel32.dll")
 
-	procShellNotifyIconW            = shell32.NewProc("Shell_NotifyIconW")
-	procRegisterClassExW            = user32.NewProc("RegisterClassExW")
-	procCreateWindowExW             = user32.NewProc("CreateWindowExW")
-	procDestroyWindow               = user32.NewProc("DestroyWindow")
+	procShellNotifyIconW = shell32.NewProc("Shell_NotifyIconW")
+	procRegisterClassExW = user32.NewProc("RegisterClassExW")
+	procCreateWindowExW  = user32.NewProc("CreateWindowExW")
+
 	procDefWindowProcW              = user32.NewProc("DefWindowProcW")
 	procSetForegroundWindow         = user32.NewProc("SetForegroundWindow")
 	procTrackPopupMenu              = user32.NewProc("TrackPopupMenu")
@@ -627,6 +627,8 @@ func (t *win32Tray) Run() error {
 }
 
 // Destroy removes the tray icon, destroys the window, and frees resources.
+// Safe to call from any goroutine — uses PostMessage to dispatch to the
+// window's thread where DestroyWindow is called via WM_DESTROY handler.
 func (t *win32Tray) Destroy() {
 	// Remove icon from tray.
 	if t.visible {
@@ -635,14 +637,17 @@ func (t *win32Tray) Destroy() {
 		}
 	}
 
-	// Unregister from the global registry.
+	// Post WM_CLOSE to the window. This is thread-safe (PostMessage works from
+	// any thread). DefWindowProc handles WM_CLOSE by calling DestroyWindow on
+	// the correct thread, which triggers WM_DESTROY → PostQuitMessage → Run() exits.
 	if t.hwnd != 0 {
 		trayMu.Lock()
 		delete(trayRegistry, t.hwnd)
 		trayMu.Unlock()
 
-		if ret, _, _ := procDestroyWindow.Call(t.hwnd); ret == 0 {
-			slog.Warn("systray: DestroyWindow failed during cleanup")
+		ret, _, _ := procPostMessageW.Call(t.hwnd, 0x0010, 0, 0) // WM_CLOSE = 0x0010
+		if ret == 0 {
+			slog.Warn("systray: PostMessage WM_CLOSE failed during Destroy")
 		}
 		t.hwnd = 0
 	}


### PR DESCRIPTION
## v0.2.3

### Fixed

- **Windows: tray.Remove() from background goroutine failed.** Replaced DestroyWindow with PostMessage(WM_CLOSE) — thread-safe, triggers correct cleanup chain on the owning thread (#14)
- **macOS: tray.Remove() from background goroutine crashed (SIGTRAP).** Destroy() now dispatches via performSelectorOnMainThread using nil sentinel in pending updates channel (#14)