### PR TITLE
release: v0.2.4 — Fix Run() exit after Remove()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.4] - 2026-08-05
+
+### Fixed
+
+- **Windows: `Run()` still not exiting after `Remove()`.** The v0.2.3 fix deleted the tray from `trayRegistry` before posting `WM_CLOSE`, so the `WM_DESTROY` handler couldn't find the tray and never called `PostQuitMessage`. Now `Destroy()` only posts `WM_CLOSE`; all cleanup (registry, HICON, HMENU, `PostQuitMessage`) happens in the `WM_DESTROY` handler on the correct thread. ([#14](https://github.com/gogpu/systray/issues/14))
+- **macOS: `Run()` still not exiting after `Remove()`.** `[NSApp stop:]` sets a flag but `[NSApp run]` only checks it after processing an event. Added `CFRunLoopStop()` via CoreFoundation FFI to immediately wake the blocked run loop (GLFW/SDL/Qt pattern). ([#14](https://github.com/gogpu/systray/issues/14))
+
 ## [0.2.3] - 2026-08-05
 
 ### Fixed
@@ -82,7 +89,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Run() message loop for standalone usage
 - 72 tests, 84% public API coverage
 
-[Unreleased]: https://github.com/gogpu/systray/compare/v0.2.3...HEAD
+[Unreleased]: https://github.com/gogpu/systray/compare/v0.2.4...HEAD
+[0.2.4]: https://github.com/gogpu/systray/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/gogpu/systray/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/gogpu/systray/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/gogpu/systray/compare/v0.2.0...v0.2.1

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,6 +18,7 @@ All three platforms implemented and production-ready:
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
+| **v0.2.4** | 2026-08-05 | Fix Run() exit: Windows WM_DESTROY cleanup ordering, macOS CFRunLoopStop wake |
 | **v0.2.3** | 2026-08-05 | Fix Destroy() from background goroutine (Windows PostMessage, macOS main thread dispatch) |
 | **v0.2.2** | 2026-08-05 | Fix Windows submenu dispatch, UpdateItem on submenus, Run() exit; IsChecked/IsDisabled getters |
 | **v0.2.1** | 2026-07-28 | Fix macOS crash on background goroutine menu updates (main thread dispatch) |

--- a/internal/darwin/objc.go
+++ b/internal/darwin/objc.go
@@ -680,3 +680,65 @@ func NewNSData(data []byte) ID {
 		uintptr(len(data)),
 	)
 }
+
+// cfRunLoop holds CoreFoundation run loop function pointers.
+var cfRunLoop struct {
+	once             sync.Once
+	err              error
+	cfRunLoopGetMain unsafe.Pointer
+	cfRunLoopStop    unsafe.Pointer
+	cifGetMain       *types.CallInterface
+	cifStop          *types.CallInterface
+}
+
+func initCFRunLoop() error {
+	cfRunLoop.once.Do(func() {
+		cf, err := ffi.LoadLibrary(
+			"/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation")
+		if err != nil {
+			cfRunLoop.err = err
+			return
+		}
+		cfRunLoop.cfRunLoopGetMain, err = ffi.GetSymbol(cf, "CFRunLoopGetMain")
+		if err != nil {
+			cfRunLoop.err = err
+			return
+		}
+		cfRunLoop.cfRunLoopStop, err = ffi.GetSymbol(cf, "CFRunLoopStop")
+		if err != nil {
+			cfRunLoop.err = err
+			return
+		}
+		cfRunLoop.cifGetMain = &types.CallInterface{}
+		err = ffi.PrepareCallInterface(cfRunLoop.cifGetMain, types.DefaultCall,
+			types.PointerTypeDescriptor, []*types.TypeDescriptor{})
+		if err != nil {
+			cfRunLoop.err = err
+			return
+		}
+		cfRunLoop.cifStop = &types.CallInterface{}
+		err = ffi.PrepareCallInterface(cfRunLoop.cifStop, types.DefaultCall,
+			types.VoidTypeDescriptor, []*types.TypeDescriptor{types.PointerTypeDescriptor})
+		if err != nil {
+			cfRunLoop.err = err
+			return
+		}
+	})
+	return cfRunLoop.err
+}
+
+// CFRunLoopStop stops the main CoreFoundation run loop, immediately waking
+// [NSApp run]. Thread-safe per Apple documentation.
+func CFRunLoopStop() {
+	if err := initCFRunLoop(); err != nil {
+		return
+	}
+	var mainLoop uintptr
+	_, _ = ffi.CallFunction(cfRunLoop.cifGetMain, cfRunLoop.cfRunLoopGetMain,
+		unsafe.Pointer(&mainLoop), nil)
+	if mainLoop == 0 {
+		return
+	}
+	_, _ = ffi.CallFunction(cfRunLoop.cifStop, cfRunLoop.cfRunLoopStop,
+		nil, []unsafe.Pointer{unsafe.Pointer(&mainLoop)})
+}

--- a/internal/platform_darwin.go
+++ b/internal/platform_darwin.go
@@ -840,7 +840,10 @@ func (t *darwinTray) destroyOnMainThread() {
 	t.nsMenu = 0
 
 	// Stop the run loop if we started it.
+	// [NSApp stop:nil] sets a flag but [NSApp run] only checks it after
+	// processing an event. CFRunLoopStop wakes the blocked run loop immediately.
 	if !t.nsApp.IsNil() {
 		t.nsApp.SendPtr(darwinSels.stop, 0)
+		darwin.CFRunLoopStop()
 	}
 }

--- a/internal/platform_windows.go
+++ b/internal/platform_windows.go
@@ -641,32 +641,12 @@ func (t *win32Tray) Destroy() {
 	// any thread). DefWindowProc handles WM_CLOSE by calling DestroyWindow on
 	// the correct thread, which triggers WM_DESTROY → PostQuitMessage → Run() exits.
 	if t.hwnd != 0 {
-		trayMu.Lock()
-		delete(trayRegistry, t.hwnd)
-		trayMu.Unlock()
-
 		ret, _, _ := procPostMessageW.Call(t.hwnd, 0x0010, 0, 0) // WM_CLOSE = 0x0010
 		if ret == 0 {
 			slog.Warn("systray: PostMessage WM_CLOSE failed during Destroy")
 		}
-		t.hwnd = 0
 	}
-
-	// Free HICON.
-	if t.hicon != 0 {
-		if ret, _, _ := procDestroyIcon.Call(t.hicon); ret == 0 {
-			slog.Warn("systray: DestroyIcon failed during cleanup")
-		}
-		t.hicon = 0
-	}
-
-	// Free HMENU.
-	if t.hmenu != 0 {
-		if ret, _, _ := procDestroyMenu.Call(t.hmenu); ret == 0 {
-			slog.Warn("systray: DestroyMenu failed during cleanup")
-		}
-		t.hmenu = 0
-	}
+	// Registry cleanup, HICON/HMENU free in WM_DESTROY handler (correct thread).
 }
 
 // makeNID builds a NOTIFYICONDATAW with current state.
@@ -911,6 +891,18 @@ func trayWndProc(hwnd uintptr, msg uint32, wParam, lParam uintptr) uintptr {
 		return ret
 
 	case wmDestroy:
+		trayMu.Lock()
+		delete(trayRegistry, hwnd)
+		trayMu.Unlock()
+		if t.hicon != 0 {
+			procDestroyIcon.Call(t.hicon)
+			t.hicon = 0
+		}
+		if t.hmenu != 0 {
+			procDestroyMenu.Call(t.hmenu)
+			t.hmenu = 0
+		}
+		t.hwnd = 0
 		procPostQuitMessage.Call(0)
 		return 0
 


### PR DESCRIPTION
## v0.2.4

### Fixed

- **Windows: Run() still not exiting after Remove().** v0.2.3 deleted trayRegistry before posting WM_CLOSE, so WM_DESTROY handler couldn't find the tray. Now Destroy() only posts WM_CLOSE; all cleanup in WM_DESTROY on the correct thread. (#14)
- **macOS: Run() still not exiting after Remove().** [NSApp stop:] needs an event to wake the run loop. Added CFRunLoopStop() via CoreFoundation FFI (GLFW/SDL/Qt pattern). (#14)