### PR TITLE
release: v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.5] - 2026-08-05
+
+### Fixed
+
+- **macOS: `Run()` still not exiting after `Remove()`.** The v0.2.4 fix called `CFRunLoopStop` from `destroyOnMainThread`, but `destroyOnMainThread` was dispatched via `performSelectorOnMainThread:waitUntilDone:YES` — which itself requires the run loop to process events (chicken-and-egg). Fix: call `[NSApp stop:]` + `CFRunLoopStop()` directly from `Destroy()` (both are thread-safe) to wake and stop the run loop first, then dispatch cleanup with `waitUntilDone:NO`. ([#14](https://github.com/gogpu/systray/issues/14))
+
 ## [0.2.4] - 2026-08-05
 
 ### Fixed
@@ -89,7 +95,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Run() message loop for standalone usage
 - 72 tests, 84% public API coverage
 
-[Unreleased]: https://github.com/gogpu/systray/compare/v0.2.4...HEAD
+[Unreleased]: https://github.com/gogpu/systray/compare/v0.2.5...HEAD
+[0.2.5]: https://github.com/gogpu/systray/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/gogpu/systray/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/gogpu/systray/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/gogpu/systray/compare/v0.2.1...v0.2.2

--- a/internal/platform_darwin.go
+++ b/internal/platform_darwin.go
@@ -799,19 +799,29 @@ func (t *darwinTray) Run() error {
 }
 
 // Destroy releases all resources associated with the tray icon.
-// Safe to call from any goroutine — AppKit calls are dispatched to the main
-// thread via performSelectorOnMainThread.
+// Safe to call from any goroutine.
 func (t *darwinTray) Destroy() {
 	if t.target.IsNil() {
 		return
 	}
 
-	// Queue the cleanup work for main thread execution.
+	// Queue cleanup for main thread execution.
 	t.pendingUpdates <- nil // nil sentinel signals destroy
 
+	// Stop the run loop first: [NSApp stop:nil] sets a flag (thread-safe),
+	// then CFRunLoopStop wakes the blocked mach_msg so [NSApp run] can check
+	// the flag and exit. This must happen BEFORE performSelectorOnMainThread
+	// because performSelector needs the run loop to be processing events.
+	if !t.nsApp.IsNil() {
+		t.nsApp.SendPtr(darwinSels.stop, 0)
+		darwin.CFRunLoopStop()
+	}
+
+	// Dispatch cleanup to main thread. waitUntilDone:NO because the run loop
+	// is about to exit — cleanup will execute as Run() unwinds.
 	drainSel := darwin.RegisterSelector("drainUpdates:")
 	darwin.MsgSend3Ptr(t.target, darwinSels.performSelectorOnMainThread,
-		uintptr(drainSel), 0, 1) // waitUntilDone:YES
+		uintptr(drainSel), 0, 0) // waitUntilDone:NO
 }
 
 // destroyOnMainThread performs the actual AppKit cleanup.
@@ -838,12 +848,4 @@ func (t *darwinTray) destroyOnMainThread() {
 	t.statusItem = 0
 	t.btn = 0
 	t.nsMenu = 0
-
-	// Stop the run loop if we started it.
-	// [NSApp stop:nil] sets a flag but [NSApp run] only checks it after
-	// processing an event. CFRunLoopStop wakes the blocked run loop immediately.
-	if !t.nsApp.IsNil() {
-		t.nsApp.SendPtr(darwinSels.stop, 0)
-		darwin.CFRunLoopStop()
-	}
 }


### PR DESCRIPTION
## v0.2.5

### Fixed

- **macOS: Run() still not exiting after Remove().** v0.2.4 called CFRunLoopStop from destroyOnMainThread, which was dispatched via performSelectorOnMainThread:waitUntilDone:YES — deadlock because the run loop must process events for performSelector to fire. Fix: stop + CFRunLoopStop directly from Destroy() (thread-safe), then dispatch cleanup with waitUntilDone:NO. (#14)