### PR TITLE
fix(windows): SetLabel/SetDisabled no-op for submenu container items (#25)

### DIFF
--- a/internal/platform_windows.go
+++ b/internal/platform_windows.go
@@ -259,6 +259,7 @@ type win32Tray struct {
 	menu       *Menu                // stored menu for rebuilding HMENU and dispatch
 	itemIDs    map[uint32]uint32    // MenuItem.ID() -> HMENU command ID (UINT) for UpdateItem
 	itemHMenus map[uint32]uintptr   // MenuItem.ID() -> owning HMENU handle (for submenu UpdateItem)
+	itemPos    map[uint32]uint32    // MenuItem.ID() -> position within owning HMENU (submenu containers, fByPosition lookup)
 	cmdItems   map[uint32]*MenuItem // command ID -> MenuItem for click dispatch (flat, includes submenus)
 	nextCmdID  uint32               // global command ID counter (1-based, increments across submenus)
 }
@@ -269,6 +270,7 @@ func NewPlatformTray(callbacks *Callbacks) PlatformTray {
 		callbacks:  callbacks,
 		itemIDs:    make(map[uint32]uint32),
 		itemHMenus: make(map[uint32]uintptr),
+		itemPos:    make(map[uint32]uint32),
 		cmdItems:   make(map[uint32]*MenuItem),
 	}
 }
@@ -449,6 +451,7 @@ func (t *win32Tray) SetMenu(menu *Menu) error {
 	t.menu = menu
 	t.itemIDs = make(map[uint32]uint32)
 	t.itemHMenus = make(map[uint32]uintptr)
+	t.itemPos = make(map[uint32]uint32)
 	t.cmdItems = make(map[uint32]*MenuItem)
 	t.nextCmdID = 1
 
@@ -739,6 +742,7 @@ func (t *win32Tray) buildHMENU(menu *Menu) (uintptr, error) {
 // Each non-separator, non-submenu item gets a globally unique command ID
 // from t.nextCmdID, ensuring submenus dispatch correctly.
 func (t *win32Tray) populateMenu(hmenu uintptr, menu *Menu) error {
+	pos := 0
 	for i, item := range menu.Items {
 		switch item.Type {
 		case MenuItemSeparator:
@@ -751,6 +755,7 @@ func (t *win32Tray) populateMenu(hmenu uintptr, menu *Menu) error {
 			if ret == 0 {
 				return fmt.Errorf("AppendMenuW separator failed at index %d", i)
 			}
+			pos++
 
 		case MenuItemSubmenu:
 			if item.Submenu == nil {
@@ -780,6 +785,13 @@ func (t *win32Tray) populateMenu(hmenu uintptr, menu *Menu) error {
 				return fmt.Errorf("AppendMenuW submenu %q failed", item.Label)
 			}
 
+			// MF_POPUP items carry the submenu HMENU in the ID slot instead of
+			// a command ID, so SetMenuItemInfoW cannot find them by ID. Record
+			// the owning HMENU and position for fByPosition-based updates.
+			t.itemHMenus[item.ID()] = hmenu
+			t.itemPos[item.ID()] = uint32(pos)
+			pos++
+
 		default: // MenuItemNormal, MenuItemCheckbox
 			label, err := windows.UTF16PtrFromString(item.Label)
 			if err != nil {
@@ -806,6 +818,7 @@ func (t *win32Tray) populateMenu(hmenu uintptr, menu *Menu) error {
 			t.itemIDs[item.ID()] = cmdID
 			t.itemHMenus[item.ID()] = hmenu
 			t.cmdItems[cmdID] = item
+			pos++
 		}
 	}
 	return nil
@@ -813,14 +826,25 @@ func (t *win32Tray) populateMenu(hmenu uintptr, menu *Menu) error {
 
 // UpdateItem updates a single menu item's native properties in-place via SetMenuItemInfoW.
 // Uses the per-item HMENU handle to correctly update items in submenus.
+// Submenu containers (MF_POPUP items) carry their submenu HMENU in the ID slot
+// instead of a command ID, so they are resolved by position (fByPosition=TRUE).
 func (t *win32Tray) UpdateItem(item *MenuItem) error {
-	cmdID, ok := t.itemIDs[item.ID()]
-	if !ok {
-		return nil
-	}
 	hmenu, ok := t.itemHMenus[item.ID()]
 	if !ok || hmenu == 0 {
 		return nil
+	}
+
+	var uItem uintptr
+	byPosition := false
+	if pos, isContainer := t.itemPos[item.ID()]; isContainer {
+		uItem = uintptr(pos)
+		byPosition = true
+	} else {
+		cmdID, ok := t.itemIDs[item.ID()]
+		if !ok {
+			return nil
+		}
+		uItem = uintptr(cmdID)
 	}
 
 	label, err := windows.UTF16PtrFromString(item.Label)
@@ -843,7 +867,11 @@ func (t *win32Tray) UpdateItem(item *MenuItem) error {
 		dwTypeData: uintptr(unsafe.Pointer(label)),
 	}
 
-	ret, _, _ := procSetMenuItemInfoW.Call(hmenu, uintptr(cmdID), 0, uintptr(unsafe.Pointer(&mii)))
+	fByPosition := uintptr(0)
+	if byPosition {
+		fByPosition = 1
+	}
+	ret, _, _ := procSetMenuItemInfoW.Call(hmenu, uItem, fByPosition, uintptr(unsafe.Pointer(&mii)))
 	if ret == 0 {
 		return fmt.Errorf("SetMenuItemInfoW failed for item %q", item.Label)
 	}

--- a/internal/platform_windows_test.go
+++ b/internal/platform_windows_test.go
@@ -1,0 +1,258 @@
+//go:build windows
+
+package internal
+
+import (
+	"testing"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// procGetMenuItemInfoW is used only by tests to verify that SetMenuItemInfoW
+// updates landed on the native Win32 menu.
+var procGetMenuItemInfoW = windows.NewLazySystemDLL("user32.dll").NewProc("GetMenuItemInfoW")
+
+// getMenuItemInfo reads back a native menu item's string and state via
+// GetMenuItemInfoW, mirroring the menuItemInfoW layout used by SetMenuItemInfoW.
+func getMenuItemInfo(t *testing.T, hmenu uintptr, uItem uintptr, byPosition bool) (string, uint32) {
+	t.Helper()
+
+	buf := make([]uint16, 256)
+	mii := menuItemInfoW{
+		cbSize:     uint32(unsafe.Sizeof(menuItemInfoW{})),
+		fMask:      miimString | miimState,
+		dwTypeData: uintptr(unsafe.Pointer(&buf[0])),
+		cch:        uint32(len(buf)),
+	}
+
+	fByPosition := uintptr(0)
+	if byPosition {
+		fByPosition = 1
+	}
+	ret, _, _ := procGetMenuItemInfoW.Call(hmenu, uItem, fByPosition, uintptr(unsafe.Pointer(&mii)))
+	if ret == 0 {
+		t.Fatalf("GetMenuItemInfoW failed for hmenu=%#x uItem=%#x byPosition=%v", hmenu, uItem, byPosition)
+	}
+
+	return windows.UTF16ToString(buf), mii.fState
+}
+
+// newTestWin32Tray builds a real Win32 tray without creating the message-only
+// window: buildHMENU/populateMenu/UpdateItem do not require an HWND.
+func newTestWin32Tray() *win32Tray {
+	return NewPlatformTray(nil).(*win32Tray)
+}
+
+func TestUpdateItem_SubmenuContainer_Label(t *testing.T) {
+	tray := newTestWin32Tray()
+
+	sub := NewMenu()
+	sub.Add("SubItem", nil)
+
+	root := NewMenu()
+	root.Add("Top", nil)
+	root.AddSeparator()
+	container := root.AddSubmenu("Options", sub)
+	root.Add("Bottom", nil)
+
+	if err := tray.SetMenu(root); err != nil {
+		t.Fatalf("SetMenu: %v", err)
+	}
+	defer procDestroyMenu.Call(tray.hmenu)
+
+	// Native layout: Top(0), separator(1), Options(2), Bottom(3).
+	pos, ok := tray.itemPos[container.ID()]
+	if !ok {
+		t.Fatal("submenu container not registered in itemPos")
+	}
+	if pos != 2 {
+		t.Errorf("container position = %d, want 2", pos)
+	}
+
+	container.Label = "Settings"
+	if err := tray.UpdateItem(container); err != nil {
+		t.Fatalf("UpdateItem: %v", err)
+	}
+
+	got, _ := getMenuItemInfo(t, tray.hmenu, uintptr(pos), true)
+	if got != "Settings" {
+		t.Errorf("container label = %q, want %q", got, "Settings")
+	}
+}
+
+func TestUpdateItem_SubmenuContainer_Disabled(t *testing.T) {
+	tray := newTestWin32Tray()
+
+	sub := NewMenu()
+	sub.Add("SubItem", nil)
+
+	root := NewMenu()
+	container := root.AddSubmenu("Options", sub)
+
+	if err := tray.SetMenu(root); err != nil {
+		t.Fatalf("SetMenu: %v", err)
+	}
+	defer procDestroyMenu.Call(tray.hmenu)
+
+	pos, ok := tray.itemPos[container.ID()]
+	if !ok {
+		t.Fatal("submenu container not registered in itemPos")
+	}
+
+	container.Disabled = true
+	if err := tray.UpdateItem(container); err != nil {
+		t.Fatalf("UpdateItem: %v", err)
+	}
+	_, state := getMenuItemInfo(t, tray.hmenu, uintptr(pos), true)
+	if state&mfsDisabled == 0 {
+		t.Errorf("container state = %#x, want MFS_DISABLED set", state)
+	}
+
+	container.Disabled = false
+	if err := tray.UpdateItem(container); err != nil {
+		t.Fatalf("UpdateItem: %v", err)
+	}
+	_, state = getMenuItemInfo(t, tray.hmenu, uintptr(pos), true)
+	if state&mfsDisabled != 0 {
+		t.Errorf("container state = %#x, want MFS_DISABLED clear", state)
+	}
+}
+
+func TestUpdateItem_SubmenuContainer_Nested(t *testing.T) {
+	tray := newTestWin32Tray()
+
+	level3 := NewMenu()
+	level3.Add("Deep", nil)
+
+	level2 := NewMenu()
+	container2 := level2.AddSubmenu("Level2", level3)
+
+	level1 := NewMenu()
+	container1 := level1.AddSubmenu("Level1", level2)
+
+	root := NewMenu()
+	root.AddSubmenu("RootSub", level1)
+
+	if err := tray.SetMenu(root); err != nil {
+		t.Fatalf("SetMenu: %v", err)
+	}
+	defer procDestroyMenu.Call(tray.hmenu)
+
+	// container1 lives inside the root submenu's HMENU at position 0.
+	pos1, ok := tray.itemPos[container1.ID()]
+	if !ok {
+		t.Fatal("nested container Level1 not registered in itemPos")
+	}
+	if pos1 != 0 {
+		t.Errorf("Level1 position = %d, want 0", pos1)
+	}
+	hmenu1, ok := tray.itemHMenus[container1.ID()]
+	if !ok {
+		t.Fatal("nested container Level1 not registered in itemHMenus")
+	}
+	if hmenu1 == tray.hmenu {
+		t.Error("Level1 owning HMENU should be the root submenu, not the root menu")
+	}
+
+	container1.Label = "Renamed"
+	if err := tray.UpdateItem(container1); err != nil {
+		t.Fatalf("UpdateItem Level1: %v", err)
+	}
+	got, _ := getMenuItemInfo(t, hmenu1, uintptr(pos1), true)
+	if got != "Renamed" {
+		t.Errorf("Level1 label = %q, want %q", got, "Renamed")
+	}
+
+	// container2 lives inside level2's HMENU at position 0.
+	pos2, ok := tray.itemPos[container2.ID()]
+	if !ok {
+		t.Fatal("nested container Level2 not registered in itemPos")
+	}
+	if pos2 != 0 {
+		t.Errorf("Level2 position = %d, want 0", pos2)
+	}
+	hmenu2, ok := tray.itemHMenus[container2.ID()]
+	if !ok {
+		t.Fatal("nested container Level2 not registered in itemHMenus")
+	}
+
+	container2.Label = "Renamed2"
+	if err := tray.UpdateItem(container2); err != nil {
+		t.Fatalf("UpdateItem Level2: %v", err)
+	}
+	got, _ = getMenuItemInfo(t, hmenu2, uintptr(pos2), true)
+	if got != "Renamed2" {
+		t.Errorf("Level2 label = %q, want %q", got, "Renamed2")
+	}
+}
+
+func TestUpdateItem_NormalItem_Regression(t *testing.T) {
+	tray := newTestWin32Tray()
+
+	sub := NewMenu()
+	subItem := sub.Add("SubItem", nil)
+
+	root := NewMenu()
+	top := root.Add("Top", nil)
+	root.AddSubmenu("Options", sub)
+
+	if err := tray.SetMenu(root); err != nil {
+		t.Fatalf("SetMenu: %v", err)
+	}
+	defer procDestroyMenu.Call(tray.hmenu)
+
+	// Root-level item resolves by command ID.
+	top.Label = "Tops"
+	if err := tray.UpdateItem(top); err != nil {
+		t.Fatalf("UpdateItem top: %v", err)
+	}
+	got, _ := getMenuItemInfo(t, tray.hmenu, uintptr(tray.itemIDs[top.ID()]), false)
+	if got != "Tops" {
+		t.Errorf("top label = %q, want %q", got, "Tops")
+	}
+
+	// Item inside a submenu resolves by command ID on the submenu's HMENU.
+	subItem.Label = "Subbed"
+	if err := tray.UpdateItem(subItem); err != nil {
+		t.Fatalf("UpdateItem subItem: %v", err)
+	}
+	got, _ = getMenuItemInfo(t, tray.itemHMenus[subItem.ID()], uintptr(tray.itemIDs[subItem.ID()]), false)
+	if got != "Subbed" {
+		t.Errorf("sub item label = %q, want %q", got, "Subbed")
+	}
+}
+
+func TestPopulateMenu_NilSubmenu_DoesNotShiftPositions(t *testing.T) {
+	tray := newTestWin32Tray()
+
+	root := NewMenu()
+	root.Add("First", nil)
+	broken := &MenuItem{id: newMenuItemID(), Label: "Broken", Type: MenuItemSubmenu} // Submenu == nil
+	root.Items = append(root.Items, broken)
+	sub := NewMenu()
+	sub.Add("SubItem", nil)
+	container := root.AddSubmenu("Options", sub)
+
+	if err := tray.SetMenu(root); err != nil {
+		t.Fatalf("SetMenu: %v", err)
+	}
+	defer procDestroyMenu.Call(tray.hmenu)
+
+	if _, ok := tray.itemPos[broken.ID()]; ok {
+		t.Error("nil-submenu item should not be registered in itemPos")
+	}
+	if _, ok := tray.itemHMenus[broken.ID()]; ok {
+		t.Error("nil-submenu item should not be registered in itemHMenus")
+	}
+
+	// Native layout: First(0), Options(1). The nil submenu appended nothing,
+	// so later items must not have shifted positions.
+	pos, ok := tray.itemPos[container.ID()]
+	if !ok {
+		t.Fatal("submenu container not registered in itemPos")
+	}
+	if pos != 1 {
+		t.Errorf("container position = %d, want 1", pos)
+	}
+}


### PR DESCRIPTION
## Problem

`AddSubmenu()` returns a `*MenuItem` handle, but calling `SetLabel()`/`SetDisabled()` on it is a silent no-op on Windows. The submenu container's native label/state never updates. (Linux already works — submenu containers are stored in `buildMenuItemMap` before the type check.)

## Root cause

Submenu containers use `MF_POPUP` in `AppendMenuW` — the `uIDNewItem` slot carries the submenu `HMENU` handle, not a command ID. `populateMenu` never registered them in `itemIDs`/`itemHMenus`, so `UpdateItem` couldn't resolve them and returned early.

## Fix

Mirrors the darwin `nsItems` fix from #24:

- `populateMenu` now records the owning `HMENU` and the append position for every submenu container in a new `itemPos` map.
- `UpdateItem` resolves submenu containers by position via `SetMenuItemInfoW` with `fByPosition=TRUE`; normal/checkbox items keep the existing command-ID path.
- Nil-`Submenu` items are skipped without shifting positions of later items.

## Tests

New `internal/platform_windows_test.go` (5 tests, run on the Windows CI runner; real Win32 round-trip verified via `GetMenuItemInfoW`):

- Container `SetLabel` / `SetDisabled` (label + MFS_DISABLED state read back)
- Two-level nested submenu containers (correct owning HMENU + position per level)
- Regression: normal items (root and inside submenu) still update by command ID
- Nil-`Submenu` items are not registered and do not shift positions

## Verification

- `go build ./...` ✅
- `go test ./...` ✅ (Windows runner, all tests pass)
- `gofmt` clean, `golangci-lint` 0 issues ✅
- Local test example verification ✅

Fixes: #25
