### PR TITLE
release: v0.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.8] - 2026-08-06
+
+### Fixed
+
+- **Windows: `SetLabel`/`SetDisabled` no-op for submenu container items.** Submenu containers use `MF_POPUP` in `AppendMenuW` — the ID slot carries the submenu `HMENU` handle, not a command ID. `populateMenu` now tracks position per item; `UpdateItem` resolves submenu containers via `SetMenuItemInfoW` with `fByPosition=TRUE`. By @nange. ([#25](https://github.com/gogpu/systray/issues/25), [#27](https://github.com/gogpu/systray/pull/27))
+
+### Added
+
+- `examples/dynamic-submenu` — demonstrates live submenu item and container label updates
+- 5 Win32 integration tests with `GetMenuItemInfoW` native readback (by @nange)
+
 ## [0.2.7] - 2026-08-06
 
 ### Fixed
@@ -107,7 +118,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Run() message loop for standalone usage
 - 72 tests, 84% public API coverage
 
-[Unreleased]: https://github.com/gogpu/systray/compare/v0.2.7...HEAD
+[Unreleased]: https://github.com/gogpu/systray/compare/v0.2.8...HEAD
+[0.2.8]: https://github.com/gogpu/systray/compare/v0.2.7...v0.2.8
 [0.2.7]: https://github.com/gogpu/systray/compare/v0.2.6...v0.2.7
 [0.2.6]: https://github.com/gogpu/systray/compare/v0.2.5...v0.2.6
 [0.2.5]: https://github.com/gogpu/systray/compare/v0.2.4...v0.2.5

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,6 +18,7 @@ All three platforms implemented and production-ready:
 
 | Version | Date | Key Changes |
 |---------|------|-------------|
+| **v0.2.8** | 2026-08-06 | Windows submenu container UpdateItem: position-based lookup (PR #27 by @nange) |
 | **v0.2.7** | 2026-08-06 | macOS submenu UpdateItem: nsItems map replaces itemWithTag (PR #24 by @nange) |
 | **v0.2.6** | 2026-08-05 | macOS Run() exit: PostAppDefinedEvent (PR #21 by @nange) |
 | **v0.2.5** | 2026-08-05 | macOS Run() exit attempt: stop+CFRunLoopStop |

--- a/examples/dynamic-submenu/main.go
+++ b/examples/dynamic-submenu/main.go
@@ -1,0 +1,102 @@
+// Example dynamic-submenu demonstrates dynamic updates on submenu items
+// and submenu containers — the fix from PRs #24 (macOS) and #27 (Windows).
+//
+// Every second, the example updates:
+//   - A counter label inside a submenu
+//   - The submenu container label itself (shows item count)
+//   - A checkbox toggle inside a submenu
+//
+// Right-click the tray icon to observe live updates.
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+	"time"
+
+	"github.com/gogpu/systray"
+)
+
+func main() {
+	tray := systray.New()
+
+	// Build submenu with dynamic items.
+	sub := systray.NewMenu()
+	counter := sub.Add("Elapsed: 0s", nil)
+	autoRefresh := sub.AddCheckbox("Auto-refresh", true, nil)
+	sub.AddSeparator()
+	sub.Add("Reset", func() {
+		counter.SetLabel("Elapsed: 0s")
+		autoRefresh.SetChecked(true)
+	})
+
+	// Build root menu.
+	root := systray.NewMenu()
+	root.Add("Status: running", nil)
+	root.AddSeparator()
+
+	// Submenu container — its label will update dynamically.
+	container := root.AddSubmenu("Options (4 items)", sub)
+
+	root.AddSeparator()
+	root.Add("Quit", func() {
+		tray.Remove()
+		os.Exit(0)
+	})
+
+	icon := generateIcon(22, color.RGBA{R: 40, G: 160, B: 80, A: 255})
+	tray.SetIcon(icon).SetTooltip("Dynamic Submenu Demo").SetMenu(root).Show()
+
+	// Background goroutine updates submenu items every second.
+	go func() {
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+		start := time.Now()
+		tick := 0
+		for range ticker.C {
+			tick++
+			elapsed := int(time.Since(start).Seconds())
+
+			// Update item inside submenu.
+			counter.SetLabel(fmt.Sprintf("Elapsed: %ds", elapsed))
+
+			// Toggle checkbox every 5 seconds.
+			if tick%5 == 0 {
+				autoRefresh.SetChecked(!autoRefresh.IsChecked())
+			}
+
+			// Update submenu container label.
+			container.SetLabel(fmt.Sprintf("Options (%ds elapsed)", elapsed))
+		}
+	}()
+
+	fmt.Println("Dynamic submenu demo running.")
+	fmt.Println("Right-click tray icon → observe 'Options' label and counter updating live.")
+	fmt.Println("Click Quit to exit.")
+
+	if err := tray.Run(); err != nil {
+		fmt.Println("Run error:", err)
+	}
+}
+
+func generateIcon(size int, c color.RGBA) []byte {
+	img := image.NewRGBA(image.Rect(0, 0, size, size))
+	mid := float64(size) / 2
+	radius := mid - 1
+	for y := 0; y < size; y++ {
+		for x := 0; x < size; x++ {
+			dx := float64(x) - mid + 0.5
+			dy := float64(y) - mid + 0.5
+			if dx*dx+dy*dy <= radius*radius {
+				img.SetRGBA(x, y, c)
+			}
+		}
+	}
+	var buf bytes.Buffer
+	_ = png.Encode(&buf, img)
+	return buf.Bytes()
+}


### PR DESCRIPTION
## v0.2.8

### Fixed

- **Windows: SetLabel/SetDisabled no-op for submenu container items.** Position-based lookup via SetMenuItemInfoW with fByPosition=TRUE. By @nange. (#25, #27)

### Added

- `examples/dynamic-submenu` — live submenu item and container label updates
- 5 Win32 integration tests with GetMenuItemInfoW native readback